### PR TITLE
Bump NuGet version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet restore
 
       - name: Pack
-        run: dotnet pack BetsBrasileiras/BetsBrasileiras.csproj --no-build -p:NuspecFile=BetsBrasileiras.nuspec -p:PackageVersion=${{ env.fullSemVer }} -p:PackageOutputPath=../nupkg
+        run: dotnet pack BetsBrasileiras/BetsBrasileiras.csproj --no-restore --no-build -p:PackageVersion=${{ env.fullSemVer }} -p:PackageOutputPath=../nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/BetsBrasileiras.${{ env.fullSemVer }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,11 @@ jobs:
       - name: Dotnet restore
         run: dotnet restore
 
+      - name: Bump NuGet version
+        run:  sed -i "s|<version>.*</version>|<version>${{ env.fullSemVer }}</version>|" BetsBrasileiras/BetsBrasileiras.nuspec
+
       - name: Pack
-        run: dotnet pack BetsBrasileiras/BetsBrasileiras.csproj --no-restore --no-build -p:PackageVersion=${{ env.fullSemVer }} -p:PackageOutputPath=../nupkg
+        run: dotnet pack BetsBrasileiras/BetsBrasileiras.csproj --no-restore --no-build -p:NuspecFile=BetsBrasileiras.nuspec -p:PackageVersion=${{ env.fullSemVer }} -p:PackageOutputPath=../nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/BetsBrasileiras.${{ env.fullSemVer }}.nupkg -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
### **User description**
## 📑 Description
Bump NuGet version

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced a new step to bump the NuGet version during the deployment process.
- Modified the `dotnet pack` command to improve efficiency by skipping the restore step.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Enhance deployment workflow with NuGet version bump</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy.yml
<li>Added a step to bump the NuGet version in the deployment workflow.<br> <li> Updated the <code>dotnet pack</code> command to use <code>--no-restore</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/BetsBrasileiras/pull/36/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

